### PR TITLE
[ORCA-197] & [ORCA-198] Update submission status before and after running submission container 

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -48,6 +48,22 @@ process GET_SUBMISSIONS {
     """
 }
 
+process UPDATE_SUBMISSION_BEFORE_RUN {
+    secret "SYNAPSE_AUTH_TOKEN"
+    container "sagebionetworks/challengeutils:v4.2.0"
+
+    input:
+    tuple val(submission_id), val(container)
+
+    output:
+    tuple val(submission_id), val(container)
+
+    script:
+    """
+    challengeutils change-status ${submission_id} EVALUATION_IN_PROGRESS
+    """
+}
+
 // runs docker containers
 process RUN_DOCKER {
     debug true
@@ -64,13 +80,28 @@ process RUN_DOCKER {
     val memory
 
     output:
-    val submission_id
-    path 'predictions.csv'
+    tuple val(submission_id), path('predictions.csv')
 
     script:
     """
     echo \$SYNAPSE_AUTH_TOKEN | docker login docker.synapse.org --username foo --password-stdin
     docker run -v \$PWD/input:/input:ro -v \$PWD:/output:rw $container
+    """
+}
+
+process UPDATE_SUBMISSION_AFTER_RUN {
+    secret "SYNAPSE_AUTH_TOKEN"
+    container "sagebionetworks/challengeutils:v4.2.0"
+
+    input:
+    tuple val(submission_id), val(output_path)
+
+    output:
+    tuple val(submission_id), val(output_path)
+
+    script:
+    """
+    challengeutils change-status ${submission_id} ACCEPTED
     """
 }
 
@@ -81,5 +112,7 @@ workflow {
     image_ch = GET_SUBMISSIONS.output 
         .splitCsv(header:true) 
         .map { row -> tuple(row.submission_id, row.image_id) }
-    RUN_DOCKER(image_ch, staged_path, params.cpus, params.memory)
+    UPDATE_SUBMISSION_BEFORE_RUN(image_ch)
+    RUN_DOCKER(UPDATE_SUBMISSION_BEFORE_RUN.output, staged_path, params.cpus, params.memory)
+    UPDATE_SUBMISSION_AFTER_RUN(RUN_DOCKER.output)
 }

--- a/main.nf
+++ b/main.nf
@@ -48,6 +48,7 @@ process GET_SUBMISSIONS {
     """
 }
 
+// change submission status to EVALUATION_IN_PROGRESS
 process UPDATE_SUBMISSION_BEFORE_RUN {
     secret "SYNAPSE_AUTH_TOKEN"
     container "sagebionetworks/challengeutils:v4.2.0"
@@ -88,6 +89,8 @@ process RUN_DOCKER {
     docker run -v \$PWD/input:/input:ro -v \$PWD:/output:rw $container
     """
 }
+
+// change submission status to ACCEPTED
 
 process UPDATE_SUBMISSION_AFTER_RUN {
     secret "SYNAPSE_AUTH_TOKEN"

--- a/modules/update_submission_status.nf
+++ b/modules/update_submission_status.nf
@@ -1,0 +1,17 @@
+// change submission status
+process UPDATE_SUBMISSION_STATUS {
+    secret "SYNAPSE_AUTH_TOKEN"
+    container "sagebionetworks/challengeutils:v4.2.0"
+
+    input:
+    tuple val(submission_id), val(previous)
+    val new_status
+
+    output:
+    tuple val(submission_id), val(previous)
+
+    script:
+    """
+    challengeutils change-status ${submission_id} ${new_status}
+    """
+}


### PR DESCRIPTION
This PR adds the processes `UPDATE_SUBMISSION_BEFORE_RUN` and `UPDATE_SUBMISSION_AFTER_RUN` to the workflow. I decided to include both of these changes in one PR because they were essentially identical tasks and testing them together made sense.

`UPDATE_SUBMISSION_BEFORE_RUN` takes the channel from our input CSV file and updates the submission status to 
`EVALUATION_IN_PROGRESS` before passing on the submission ID and docker image to `RUN_DOCKER`. `UPDATE_SUBMISSION_AFTER_RUN` then takes the submission ID from `RUN_DOCKER` and updates the submission status to `ACCEPTED`. 

Both changes have been tested successfully both separately and together locally, and then together in a Nextflow Tower run.