### PR TITLE
[ORCA-221] Adds Rudimentary Validation Step

### DIFF
--- a/bin/validate.py
+++ b/bin/validate.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+if __name__ == "__main__":
+    predictions_path = sys.argv[1]
+    invalid_reasons = []
+    if predictions_path is None:
+        prediction_status = "INVALID"
+        invalid_reasons.append("Predicitons file not found")
+    else:
+        with open(predictions_path, "r") as sub_file:
+            message = sub_file.read()
+        prediction_status = "VALIDATED"
+        if message is None:
+            prediction_status = "INVALID"
+            invalid_reasons.append("Predicitons file is empty")
+    result = {
+        "submission_errors": ";".join(invalid_reasons),
+        "submission_status": prediction_status,
+    }
+    with open("results.json", "w") as o:
+        o.write(json.dumps(result))
+    print(prediction_status)

--- a/bin/validate.py
+++ b/bin/validate.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     invalid_reasons = []
     if predictions_path is None:
         prediction_status = "INVALID"
-        invalid_reasons.append("Predicitons file not found")
+        invalid_reasons.append("Predictions file not found")
     else:
         with open(predictions_path, "r") as sub_file:
             message = sub_file.read()

--- a/modules/update_submission_status.nf
+++ b/modules/update_submission_status.nf
@@ -4,11 +4,7 @@ process UPDATE_SUBMISSION_STATUS {
     container "sagebionetworks/challengeutils:v4.2.0"
 
     input:
-    tuple val(submission_id), val(previous)
-    val new_status
-
-    output:
-    tuple val(submission_id), val(previous)
+    tuple val(submission_id), val(new_status)
 
     script:
     """

--- a/modules/validate.nf
+++ b/modules/validate.nf
@@ -1,0 +1,16 @@
+// validate submission results
+process VALIDATE {
+    secret "SYNAPSE_AUTH_TOKEN"
+    container "python:3.12.0rc1"
+
+    input:
+    tuple val(submission_id), path(predictions)
+
+    output:
+    tuple val(submission_id), path(predictions), stdout, path("*.json")
+
+    script:
+    """
+    validate.py '${predictions}'
+    """
+}


### PR DESCRIPTION
This PR adds the `VALIDATE` process to the workflow. It takes the output from the `RUN_DOCKER` process, and performs some basic validation on the `predictions.csv` file created in `RUN_DOCKER`. The validation performed includes: ensuring that a path to the csv file was actually passed to `VALIDATE`, and that the file is not empty. If both of these checks pass, a status of `VALIDATED` is passed on. If not, the `INVALID` status is passed, and a JSON file is written containing the reasons for the `INVALID` status. 

I also did some minor refactoring of the `update_submission_status.nf` module. Before, the process was only able to take a channel with a length of 2 and a hard-coded status. I have updated it to only take a channel that contains the submission ID and a new status. This way, we can mix-in the submission IDs and statuses (both hard-coded and logic-determined) in a greater variety of situations.

These changes set up a flow where the status updating processes are treated separately, while the outputs of the business logic processes flow into the next process.

These changes have been tested both locally and on [Tower](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/6MlQqDieSSYhP)